### PR TITLE
Add support for compound keys

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -411,7 +411,8 @@ export class OData {
         url += `(${id})`
         break;
       case "string":
-        url += `('${id}')`
+        // Compound Keys are not enclosed by quotes
+        url += id.includes(",") ? `(${id})` : `('${id}')`
         break;
       case "undefined":
         break;

--- a/src/request.ts
+++ b/src/request.ts
@@ -407,12 +407,15 @@ export class OData {
     var rt: BatchRequest = { url, init: { method, headers, body: "" } };
 
     switch (typeof id) {
+      case "object": 
+        const compoundId = Object.entries(id).map(kv => `${kv[0]}=${kv[1]}`).join(",")
+        url += `(${compoundId})`
+        break 
       case "number":
         url += `(${id})`
         break;
       case "string":
-        // Compound Keys are not enclosed by quotes
-        url += id.includes(",") ? `(${id})` : `('${id}')`
+        url += `('${id}')`
         break;
       case "undefined":
         break;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "experimentalDecorators": true,
     "lib": [
       "es6",
-      "dom"
+      "dom",
+      "es2017.object"
     ],
     "module": "commonjs",
     "target": "es5",

--- a/tsconfig.umd.json
+++ b/tsconfig.umd.json
@@ -8,7 +8,8 @@
     "experimentalDecorators": true,
     "lib": [
       "es6",
-      "dom"
+      "dom",
+      "es2017.object"
     ],
     "module": "commonjs",
     "target": "es5",


### PR DESCRIPTION
Compound keys are structured as `OrderItems(OrderId=1234,ProductId=1234)`. Grammar is defined [here](http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/abnf/odata-abnf-construction-rules.txt). 

Example of usage can be found [here](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752343).