### PR TITLE
Generator: Deconstruct header on metadata fetch request

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,7 +72,7 @@ const d = (string) => {
 
       const meta = await parseODataMetadataFromRemote(
         options.uri,
-        { headers: { ...GetAuthorizationPair(options.user, options.pass), }, },
+        GetAuthorizationPair(options.user, options.pass),
         fetch,
       )
 

--- a/src/generator/parser.ts
+++ b/src/generator/parser.ts
@@ -30,7 +30,7 @@ export const parseODataMetadataFromRemote = async (
   headers,
   fetch
 ) => {
-  const res = await fetch(uri, { headers, })
+  const res = await fetch(uri, { ...headers, })
   if (res.status != 200) {
     throw new Error(`Response not correct, check your network & credential\nStatus:${res.status}\nHeaders:${JSON.stringify(res.headers)}`)
   }

--- a/src/generator/parser.ts
+++ b/src/generator/parser.ts
@@ -30,7 +30,7 @@ export const parseODataMetadataFromRemote = async (
   headers,
   fetch
 ) => {
-  const res = await fetch(uri, { ...headers, })
+  const res = await fetch(uri, { headers, })
   if (res.status != 200) {
     throw new Error(`Response not correct, check your network & credential\nStatus:${res.status}\nHeaders:${JSON.stringify(res.headers)}`)
   }


### PR DESCRIPTION
On get $metadata the headers containing authentication are passed as object and assigned to header variable. This leads to an object `{ headers: { headers: { Authorization: 'Basic 123' } } }`

Example:
```
const headers = { headers: { Authorization:'Basic 123'}, }
> var req = { headers, }
{ headers: { headers: { Authorization: 'Basic 123' } } }
```

Object should be deconstructed to build it accordingly 
```
> req = { ...headers,}
{ headers: { Authorization: 'Basic 123' } }
```